### PR TITLE
Recommend `vim.g` variable over `_G` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,10 +327,10 @@ for initialization could be useful:
 
 ```lua
 -- ftplugin/rust.lua
-if not _G.did_my_rust_plugin_init then
+if not vim.g.did_my_rust_plugin_init then
     -- Initialise
 end
-_G.did_my_rust_plugin_init = true
+vim.g.did_my_rust_plugin_init = true
 
 local bufnr = vim.api.nvim_get_current_buf()
 -- do something specific to this buffer, e.g. add a <Plug> mapping or create a command


### PR DESCRIPTION
The `_G` variable belongs to Lua, Vim global variables should be stored in the `vim.g` namespace which exists for Vim variables and where they are also accessible to Vim script.