### PR TITLE
ci: report broken links in markdown (md) files

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -1,0 +1,14 @@
+name: Linkspector
+on: [pull_request]
+jobs:
+  check-links:
+    name: runner / linkspector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          fail_on_error: true


### PR DESCRIPTION
I am opening this as a suggestion. Feel free to close if you think it's a bad idea.

I added this to my own project as an experiment here, and it seemed to work in my test https://github.com/mikavilpas/yazi.nvim/pull/96

Originally I wanted to add https://github.com/marketplace/actions/markdown-link-check but its creator recommended trying this new thing out.

https://github.com/UmbrellaDocs/action-linkspector?tab=readme-ov-file