### PR TITLE
docs: update sub-command regex to support ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ vim.api.nvim_create_user_command("Rocks", my_cmd, {
     desc = "My awesome command with subcommand completions",
     complete = function(arg_lead, cmdline, _)
         -- Get the subcommand.
-        local subcmd_key, subcmd_arg_lead = cmdline:match("^Rocks[!]*%s(%S+)%s(.*)$")
+        local subcmd_key, subcmd_arg_lead = cmdline:match("^['<,'>]*Rocks[!]*%s(%S+)%s(.*)$")
         if subcmd_key 
             and subcmd_arg_lead 
             and subcommand_tbl[subcmd_key] 
@@ -176,7 +176,7 @@ vim.api.nvim_create_user_command("Rocks", my_cmd, {
             return subcommand_tbl[subcmd_key].complete(subcmd_arg_lead)
         end
         -- Check if cmdline is a subcommand
-        if cmdline:match("^Rocks[!]*%s+%w*$") then
+        if cmdline:match("^['<,'>]*Rocks[!]*%s+%w*$") then
             -- Filter subcommands that match
             local subcommand_keys = vim.tbl_keys(subcommand_tbl)
             return vim.iter(subcommand_keys)


### PR DESCRIPTION
I have a [personal Neovim plugin](https://github.com/wassimk/gh-navigator.nvim) that lets me quickly jump from Neovim into GitHub PRs and blames based on commit shas, numbers, or search queries. My first version had a bunch of root-level commands. Then I read your guide, and subcommands are easy to implement now! So I [did it](https://github.com/wassimk/gh-navigator.nvim/releases/tag/v0.1.3)! Thanks for writing it. I learned a ton. 

My commands use ranges, and I realize the example doesn't support them. Maybe adding them to the example would be nice, even if the `Rocks` command doesn't use ranges.